### PR TITLE
allow for planner arg in main_simple

### DIFF
--- a/src/domains/simple.py
+++ b/src/domains/simple.py
@@ -5,10 +5,11 @@ import copy
 
 class SimpleEnv(Environment):
 
-    def __init__(self, branch, solution_path):
+    def __init__(self, branch, solution_path, printp=False):
         self._branch = branch  # branching factor
         self._solution_path = solution_path  # path to unique solution
         self._path = []
+        self._printp = printp
 
     def copy(self):
         return copy.deepcopy(self)
@@ -31,7 +32,7 @@ class SimpleEnv(Environment):
         return self.successors()
 
     def apply_action(self, action):
-        print("path = {} action = {}".format(self._path, action))
+        if printp: print("path = {} action = {}".format(self._path, action))
         self._path.append(action)
 
     def is_solution(self):

--- a/src/main_simple.py
+++ b/src/main_simple.py
@@ -1,6 +1,8 @@
 import os
 import time
 import argparse
+import sys
+import random
 from os import listdir
 from search.bfs_levin import BFSLevin
 from search.a_star import AStar
@@ -11,17 +13,26 @@ from domains.simple import SimpleEnv
 from models.simple import SimplePolicy
 
 def main():
-    # planner = AStar(use_heuristic=False, use_learned_heuristic=False, k_expansions=32)
-    # planner = PUCT(use_heuristic=False, use_learned_heuristic=False, k_expansions=32, cpuct=1.0)
-    planner = BFSLevin(use_heuristic=False, use_learned_heuristic=False, k_expansions=32, estimated_probability_to_go=False)
+    planner = False
+    planner_str = (sys.argv[1] if (len(sys.argv) > 1) else '').lower()
+    if(planner_str == 'astar'):
+      planner = AStar(use_heuristic=False, use_learned_heuristic=False, k_expansions=32)
+    elif(planner_str == 'puct'):
+      planner = PUCT(use_heuristic=False, use_learned_heuristic=False, k_expansions=32, cpuct=1.0)
+    elif(planner_str == 'lts'):
+      planner = BFSLevin(use_heuristic=False, use_learned_heuristic=False, k_expansions=32, estimated_probability_to_go=False)
+    else:
+      print('Expected one argument in ["astar", "puct", "lts"]. Exiting.')
+      exit()
 
     branch = 2
-    state = SimpleEnv(branch=branch, solution_path=[1, 0, 0, 1])
+    state = SimpleEnv(branch=branch, solution_path=[1, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1], printp=False)
+    # state = SimpleEnv(branch=branch, solution_path=[random.randint(0, 1) for i in range(14)]) # can't compare with a random seed
     puzzle_name = "Simple1"
     model = SimplePolicy(branch=branch)
-    budget = 1000
+    budget = 100000
     start_time = time.time()
-    time_limit_seconds = 10
+    time_limit_seconds = 100
     slack_time = 0  # 600
 
     data = [False] * 7

--- a/src/search/bfs_levin.py
+++ b/src/search/bfs_levin.py
@@ -15,75 +15,75 @@ class TreeNode:
         self._action = action
         self._parent = parent
         self._probabilitiy_distribution_a = None
-    
+
     def __eq__(self, other):
         """
-        Verify if two tree nodes are identical by verifying the 
-        game state in the nodes. 
+        Verify if two tree nodes are identical by verifying the
+        game state in the nodes.
         """
         return self._game_state == other._game_state
-    
+
     def __lt__(self, other):
         """
         Function less-than used by the heap
         """
-        return self._levin_cost < other._levin_cost    
-    
+        return self._levin_cost < other._levin_cost
+
     def __hash__(self):
         """
         Hash function used in the closed list
         """
         return self._game_state.__hash__()
-    
+
     def set_probability_distribution_actions(self, d):
         self._probabilitiy_distribution_a = d
-        
+
     def get_probability_distribution_actions(self):
         return self._probabilitiy_distribution_a
-    
+
     def set_levin_cost(self, c):
         self._levin_cost = c
-    
+
     def get_p(self):
         """
         Returns the pi cost of a node
         """
         return self._p
-    
+
     def get_g(self):
         """
         Returns the pi cost of a node
         """
         return self._g
-    
+
     def get_game_state(self):
         """
         Returns the game state represented by the node
         """
         return self._game_state
-    
+
     def get_parent(self):
         """
         Returns the parent of the node
         """
         return self._parent
-    
+
     def get_action(self):
         """
         Returns the action taken to reach node stored in the node
         """
         return self._action
-        
+
 
 class BFSLevin():
-    
+
     def __init__(self, use_heuristic=True, use_learned_heuristic=False, estimated_probability_to_go=True, k_expansions=32, mix_epsilon=0.0):
         self._use_heuristic = use_heuristic
         self._use_learned_heuristic = use_learned_heuristic
         self._estimated_probability_to_go = estimated_probability_to_go
         self._k = k_expansions
         self._mix_epsilon = mix_epsilon
-            
+
     def get_levin_cost_star(self, child_node, predicted_h):
         if self._use_learned_heuristic and self._use_heuristic:
             max_h = max(predicted_h, child_node.get_game_state().heuristic_value())
@@ -91,12 +91,12 @@ class BFSLevin():
         elif self._use_learned_heuristic:
             if predicted_h < 0:
                 predicted_h = 0
-                
+
             return math.log(predicted_h + child_node.get_g()) - (child_node.get_p() * (1 + (predicted_h/child_node.get_g())))
         else:
             h_value = child_node.get_game_state().heuristic_value()
             return math.log(h_value + child_node.get_g()) - (child_node.get_p() * (1 + (h_value/child_node.get_g())))
-    
+
     def get_levin_cost(self, child_node, predicted_h):
         if self._use_learned_heuristic and self._use_heuristic:
             max_h = max(predicted_h, child_node.get_game_state().heuristic_value())
@@ -108,141 +108,141 @@ class BFSLevin():
         elif self._use_heuristic:
             return math.log(child_node.get_game_state().heuristic_value() + child_node.get_g()) - child_node.get_p()
         return math.log(child_node.get_g()) - child_node.get_p()
-    
-    
+
+
     def search(self, data):
         """
-        Performs Best-First LTS . 
-        
+        Performs Best-First LTS .
+
         Returns solution cost, number of nodes expanded, and generated
         """
-        state = data[0] 
+        state = data[0]
         puzzle_name = data[1]
         nn_model = data[2]
         budget = data[3]
         start_overall_time = data[4]
         time_limit = data[5]
         slack_time = data[6]
-        
+
         start_time = time.time()
-        
+
         _open = []
         _closed = set()
-        
+
         expanded = 0
         generated = 0
-        
+
         if self._use_learned_heuristic:
             _, action_distribution, _ = nn_model.predict(np.array([state.get_image_representation()]))
         else:
             _, action_distribution = nn_model.predict(np.array([state.get_image_representation()]))
-            
+
         action_distribution_log = np.log((1 - self._mix_epsilon) * action_distribution + (self._mix_epsilon * (1/action_distribution.shape[1])))
-        
+
         node = TreeNode(None, state, 1, 0, 0, -1)
         node.set_probability_distribution_actions(action_distribution_log[0])
-        
+
         heapq.heappush(_open, node)
         _closed.add(state)
-        
+
         # this array should big enough to have more entries than self._k + the largest number of octions
         predicted_h = np.zeros(10 * self._k)
-        
+
         children_to_be_evaluated = []
         x_input_of_children_to_be_evaluated= []
-        
+
         while len(_open) > 0:
-            
-            node = heapq.heappop(_open)                            
-                
+
+            node = heapq.heappop(_open)
+
             expanded += 1
-            
+
             end_time = time.time()
             if (budget > 0 and expanded > budget) or end_time - start_overall_time + slack_time > time_limit:
                     return -1, expanded, generated, end_time - start_time, puzzle_name
-            
+
             actions = node.get_game_state().successors_parent_pruning(node.get_action())
             probability_distribution = node.get_probability_distribution_actions()
-                       
+
             for a in actions:
                 child = copy.deepcopy(node.get_game_state())
                 child.apply_action(a)
 
-                if child.is_solution(): 
+                if child.is_solution():
                     end_time = time.time()
                     return node.get_g() + 1, expanded, generated, end_time - start_time, puzzle_name
-                
+
                 child_node = TreeNode(node, child, node.get_p() + probability_distribution[a], node.get_g() + 1, -1, a)
 
                 children_to_be_evaluated.append(child_node)
                 x_input_of_children_to_be_evaluated.append(child.get_image_representation())
-                
+
             if len(children_to_be_evaluated) >= self._k or len(_open) == 0:
                 if self._use_learned_heuristic:
                     _, action_distribution, predicted_h = nn_model.predict(np.array(x_input_of_children_to_be_evaluated))
                 else:
                     _, action_distribution = nn_model.predict(np.array(x_input_of_children_to_be_evaluated))
-                    
+
                 action_distribution_log = np.log((1 - self._mix_epsilon) * action_distribution + (self._mix_epsilon * (1/action_distribution.shape[1])))
-                
+
                 for i in range(len(children_to_be_evaluated)):
                     generated += 1
-                    
-                    if self._estimated_probability_to_go:    
+
+                    if self._estimated_probability_to_go:
                         levin_cost = self.get_levin_cost_star(children_to_be_evaluated[i], predicted_h[i])
                     else:
                         if i >= len(predicted_h):
                             levin_cost = self.get_levin_cost(children_to_be_evaluated[i], None)
                         else:
                             levin_cost = self.get_levin_cost(children_to_be_evaluated[i], predicted_h[i])
-                        
+
                     children_to_be_evaluated[i].set_probability_distribution_actions(action_distribution_log[i])
                     children_to_be_evaluated[i].set_levin_cost(levin_cost)
-                    
+
                     if children_to_be_evaluated[i].get_game_state() not in _closed:
                         heapq.heappush(_open, children_to_be_evaluated[i])
                         _closed.add(children_to_be_evaluated[i].get_game_state())
-                    
+
                 children_to_be_evaluated.clear()
                 x_input_of_children_to_be_evaluated.clear()
         print('Emptied Open List during search: ', puzzle_name)
         end_time = time.time()
         return -1, expanded, generated, end_time - start_time, puzzle_name
-        
+
     def _store_trajectory_memory(self, tree_node, expanded):
         """
-        Receives a tree node representing a solution to the problem. 
-        Backtracks the path performed by search, collecting state-action pairs along the way. 
+        Receives a tree node representing a solution to the problem.
+        Backtracks the path performed by search, collecting state-action pairs along the way.
         The state-action pairs are stored alongside the number of nodes expanded in an object of type Trajectory,
-        which is added to the variable memory. 
+        which is added to the variable memory.
         """
         states = []
         actions = []
         solution_costs = []
-        
+
         state = tree_node.get_parent()
         action = tree_node.get_action()
         cost = 1
-        
+
         while not state.get_parent() is None:
             states.append(state.get_game_state())
             actions.append(action)
             solution_costs.append(cost)
-            
+
             action = state.get_action()
             state = state.get_parent()
             cost += 1
-            
+
         states.append(state.get_game_state())
         actions.append(action)
         solution_costs.append(cost)
-        
-        return Trajectory(states, actions, solution_costs, expanded, math.exp(tree_node.get_p()))        
-     
+
+        return Trajectory(states, actions, solution_costs, expanded, math.exp(tree_node.get_p()))
+
     def search_for_learning(self, data):
         """
         Performs Best-First LTS bounded by a search budget.
-        
+
         Returns Boolean indicating whether the solution was found,
         number of nodes expanded, and number of nodes generated
         """
@@ -250,47 +250,47 @@ class BFSLevin():
         puzzle_name = data[1]
         budget = data[2]
         nn_model = data[3]
-        
+
         _open = []
         _closed = set()
-        
+
         expanded = 0
         generated = 0
-        
+
 #         print('Attempting puzzle ', puzzle_name, ' with budget: ', budget)
 #         return False, None, expanded, generated, puzzle_name
-        
+
         if self._use_learned_heuristic:
             _, action_distribution, _ = nn_model.predict(np.array([state.get_image_representation()]))
         else:
             _, action_distribution = nn_model.predict(np.array([state.get_image_representation()]))
-            
+
         action_distribution_log = np.log((1 - self._mix_epsilon) * action_distribution + (self._mix_epsilon * (1/action_distribution.shape[1])))
-        
+
         node = TreeNode(None, state, 1, 0, 0, -1)
         node.set_probability_distribution_actions(action_distribution_log[0])
-        
+
         heapq.heappush(_open, node)
         _closed.add(state)
-        
+
         # this array should big enough to have more entries than self._k + the largest number of octions
         predicted_h = np.zeros(10 * self._k)
-        
+
         children_to_be_evaluated = []
         x_input_of_children_to_be_evaluated= []
-        
+
         while len(_open) > 0:
-            
-            node = heapq.heappop(_open)                            
-                
+
+            node = heapq.heappop(_open)
+
             expanded += 1
 
             actions = node.get_game_state().successors_parent_pruning(node.get_action())
             probability_distribution_log = node.get_probability_distribution_actions()
-            
+
             if expanded >= budget:
                 return False, None, expanded, generated, puzzle_name
-                            
+
             for a in actions:
                 child = copy.deepcopy(node.get_game_state())
 #                 child = node.get_game_state().copy()
@@ -298,27 +298,27 @@ class BFSLevin():
 
                 child_node = TreeNode(node, child, node.get_p() + probability_distribution_log[a], node.get_g() + 1, -1, a)
 
-                if child.is_solution(): 
+                if child.is_solution():
                     print('Solved puzzle: ', puzzle_name, ' expanding ', expanded, ' with budget: ', budget)
                     trajectory = self._store_trajectory_memory(child_node, expanded)
                     return True, trajectory, expanded, generated, puzzle_name
 
                 children_to_be_evaluated.append(child_node)
                 x_input_of_children_to_be_evaluated.append(child.get_image_representation())
-                
+
             if len(children_to_be_evaluated) >= self._k or len(_open) == 0:
 
                 if self._use_learned_heuristic:
                     _, action_distribution, predicted_h = nn_model.predict(np.array(x_input_of_children_to_be_evaluated))
                 else:
                     _, action_distribution = nn_model.predict(np.array(x_input_of_children_to_be_evaluated))
-                
+
                 action_distribution_log = np.log((1 - self._mix_epsilon) * action_distribution + (self._mix_epsilon * (1/action_distribution.shape[1])))
-                
+
                 for i in range(len(children_to_be_evaluated)):
                     generated += 1
-                    
-                    if self._estimated_probability_to_go:    
+
+                    if self._estimated_probability_to_go:
                         levin_cost = self.get_levin_cost_star(children_to_be_evaluated[i], predicted_h[i])
                     else:
                         if i >= len(predicted_h):
@@ -327,12 +327,12 @@ class BFSLevin():
                             levin_cost = self.get_levin_cost(children_to_be_evaluated[i], predicted_h[i])
                     children_to_be_evaluated[i].set_probability_distribution_actions(action_distribution_log[i])
                     children_to_be_evaluated[i].set_levin_cost(levin_cost)
-    
-                    
+
+
                     if children_to_be_evaluated[i].get_game_state() not in _closed:
                         heapq.heappush(_open, children_to_be_evaluated[i])
                         _closed.add(children_to_be_evaluated[i].get_game_state())
-                    
+
                 children_to_be_evaluated.clear()
                 x_input_of_children_to_be_evaluated.clear()
         print('Emptied Open List in puzzle: ', puzzle_name)

--- a/src/search/puct.py
+++ b/src/search/puct.py
@@ -10,7 +10,7 @@ class PUCTTreeNode:
         self._action = action
         self._parent = parent
         self._g = g_cost
-        
+
         self._actions = game_state.successors()
         self._N = {}
         self._W = {}
@@ -19,11 +19,11 @@ class PUCTTreeNode:
         self._virtual_loss = {}
         self._children = {}
         self._num_children_expanded = 0
-        
+
         self._is_fully_expanded = False
-        
+
         self._N_total = 0
-        
+
         for a in self._actions:
             self._N[a] = 0
             self._W[a] = 0
@@ -31,57 +31,57 @@ class PUCTTreeNode:
             self._virtual_loss[a] = 0
             self._children[a] = None
             self._P[a] = action_probs[a]
-            
+
     def update_action_value(self, action, value):
         self._N_total += 1
         self._N[action] += 1
-        
+
 #         if self._Q[action] is None or value < self._Q[action]:
 #             self._Q[action] = value
-        
+
         self._W[action] += value
         self._Q[action] = self._W[action] / self._N[action]
-    
+
     def is_root(self):
         return self._parent is None
-    
+
     def get_uct_values(self, max_q, min_q):
         normalized_Q = {}
-        
+
         if max_q == min_q:
             max_q = 1
             min_q = 0
-        
+
         for a, q in self._Q.items():
             normalized_Q[a] = (q + self._virtual_loss[a] - min_q) / (max_q - min_q)
-                                        
+
         uct_values = {}
         for a in self._actions:
-            uct_values[a] = normalized_Q[a] - self.c * self._P[a] * (np.math.sqrt(self._N_total)/(1 + self._N[a])) 
-        
+            uct_values[a] = normalized_Q[a] - self.c * self._P[a] * (np.math.sqrt(self._N_total)/(1 + self._N[a]))
+
         return uct_values
-    
+
     def add_virtual_loss(self, action, max_q):
         self._virtual_loss[action] += max_q
-        
+
     def remove_virtual_loss(self, action):
         self._virtual_loss[action] = 0
-    
+
     def argmin_uct_values(self, max_q, min_q):
         if not self._is_fully_expanded:
             action_to_return = None
             for i in range(len(self._actions)):
                 if self._children[self._actions[i]] is None:
                     action_to_return = self._actions[i]
-                    
+
                     return action_to_return
-        
+
         uct_values = self.get_uct_values(max_q, min_q)
-        
+
         is_first = True
         min_value = 0
         min_action = None
-        
+
         for action, value in uct_values.items():
             if is_first:
                 min_action = action
@@ -89,73 +89,73 @@ class PUCTTreeNode:
                 is_first = False
             elif value < min_value:
                 min_action = action
-                min_value = value       
-        
+                min_value = value
+
         return min_action
-    
+
     def get_child(self, action):
         return self._children[action]
-    
+
     def is_leaf(self, action):
         return self._N[action] == 0
-    
+
     def add_child(self, child, action):
         self._children[action] = child
-        
+
         self._num_children_expanded += 1
-                    
+
         if self._num_children_expanded == len(self._actions):
             self._is_fully_expanded = True
-        
+
     def get_g(self):
         """
         Returns the pi cost of a node
         """
         return self._g
-    
+
     def __eq__(self, other):
         """
-        Verify if two tree nodes are identical by verifying the 
-        game state in the nodes. 
+        Verify if two tree nodes are identical by verifying the
+        game state in the nodes.
         """
         return self._game_state == other._game_state
-    
+
     def get_game_state(self):
         """
         Returns the game state represented by the node
         """
         return self._game_state
-    
+
     def get_parent(self):
         """
         Returns the parent of the node
         """
         return self._parent
-    
+
     def get_action(self):
         """
         Returns the action taken to reach node stored in the node
         """
         return self._action
-    
+
     def get_actions(self):
         """
         Returns the actions available at the state represented by the node
         """
         return self._actions
-        
+
 
 class PUCT():
-    
+
     def __init__(self, use_heuristic=True, use_learned_heuristic=False, k_expansions=32, cpuct=1.0):
         self._use_heuristic = use_heuristic
         self._use_learned_heuristic = use_learned_heuristic
         self._k = k_expansions
         self._cpuct = cpuct
-        
+
         self._max_q = None
         self._min_q = None
-        
+
     def _get_v_value(self, child, predicted_h):
         if self._use_heuristic and self._use_learned_heuristic:
             return max(child.heuristic_value(), predicted_h)
@@ -163,88 +163,88 @@ class PUCT():
             return predicted_h
         else:
             return child.heuristic_value()
-        
+
     def _expand(self, root):
         current_node = root
-        
+
         if self._max_q is None or self._min_q is None:
             max_q = 1
             min_q = 0
         else:
             max_q = self._max_q
-            min_q = self._min_q        
-        
+            min_q = self._min_q
+
         action = current_node.argmin_uct_values(max_q, min_q)
-        
+
         while not current_node.is_leaf(action):
             current_node.add_virtual_loss(action, max_q)
-            
+
             current_node = current_node.get_child(action)
             action = current_node.argmin_uct_values(max_q, min_q)
-            
+
             if action is None:
                 self._backpropagate([current_node], [max_q])
-                
+
                 return current_node, action
 
         return current_node, action
 
     def _evaluate(self, nodes, actions):
-        
+
         children = []
         children_image = []
-        
+
         for i in range(len(nodes)):
             child_state = nodes[i].get_game_state().copy()
             child_state.apply_action(actions[i])
-            
+
             children.append(child_state)
             children_image.append(child_state.get_image_representation())
-        
-        
+
+
         predicted_h = np.zeros(len(children))
         if self._use_learned_heuristic:
             _, action_probs, predicted_h = self._nn_model.predict(np.array(children_image))
         else:
 #             print(np.array(children_image).shape)
             _, action_probs = self._nn_model.predict(np.array(children_image))
-        
+
         child_nodes = []
         child_values = []
-        
+
         for i in range(len(children)):
             child_node = PUCTTreeNode(nodes[i], children[i], actions[i], action_probs[i], nodes[i].get_g() + 1, self._cpuct)
             nodes[i].add_child(child_node, actions[i])
             v = self._get_v_value(children[i], predicted_h[i])
-            
+
             child_nodes.append(child_node)
             child_values.append(v)
-        
+
             if self._max_q is None or v > self._max_q:
                 self._max_q = v
-                
+
             if self._min_q is None or v < self._min_q:
                 self._min_q = v
-        
+
         return child_nodes, child_values
-        
+
     def _backpropagate(self, leaves, values):
-        
+
         for i in range(len(leaves)):
             node = leaves[i]
-            
+
             while not node.is_root():
                 parent = node.get_parent()
                 parent.update_action_value(node.get_action(), values[i])
-                
+
                 parent.remove_virtual_loss(node.get_action())
-                
-                node = parent    
-    
+
+                node = parent
+
     def search_for_learning(self, data):
         """
         Performs PUCT search bounded by a search budget.
-        
+
         Returns Boolean indicating whether the solution was found,
         number of nodes expanded, and number of nodes generated
         """
@@ -252,142 +252,140 @@ class PUCT():
         puzzle_name = data[1]
         budget = data[2]
         self._nn_model = data[3]
-        
+
         expanded = 0
-        
+
         if self._use_learned_heuristic:
             _, action_probs, _ = self._nn_model.predict(np.array([state.get_image_representation()]))
         else:
             _, action_probs = self._nn_model.predict(np.array([state.get_image_representation()]))
-        
+
         root = PUCTTreeNode(None, state, -1, action_probs[0], 0, self._cpuct)
-        
+
         while True:
             nodes = []
             actions = []
             number_trials = 0
             while len(nodes) == 0:
                 distinct_nodes = set()
-                
+
                 for _ in range(self._k):
                     leaf_node, action = self._expand(root)
-                    
+
                     if number_trials % 100 == 0 and number_trials != 0:
                         print(number_trials)
-                    
+
                     if action is None:
                         number_trials += 1
                         continue
-                    
+
                     if leaf_node.get_game_state() not in distinct_nodes:
                         distinct_nodes.add(leaf_node.get_game_state())
-                        
+
                         nodes.append(leaf_node)
                         actions.append(action)
-                        
+
                         expanded += 1
-            
+
             leaves, values = self._evaluate(nodes, actions)
-            
+
             if expanded >= budget:
                 return False, None, expanded, 0, puzzle_name
-            
+
             for leaf_node in leaves:
                 if leaf_node.get_game_state().is_solution():
                     print('Solved puzzle: ', puzzle_name)
                     trajectory = self._store_trajectory_memory(leaf_node, expanded)
                     return True, trajectory, expanded, 0, puzzle_name
-            
+
             self._backpropagate(leaves, values)
-   
-        
+
+
     def _store_trajectory_memory(self, tree_node, expanded):
         """
-        Receives a tree node representing a solution to the problem. 
-        Backtracks the path performed by search, collecting state-action pairs along the way. 
+        Receives a tree node representing a solution to the problem.
+        Backtracks the path performed by search, collecting state-action pairs along the way.
         The state-action pairs are stored alongside the number of nodes expanded in an object of type Trajectory,
-        which is added to the variable memory. 
+        which is added to the variable memory.
         """
         states = []
         actions = []
         solution_costs = []
-        
+
         state = tree_node.get_parent()
         action = tree_node.get_action()
         cost = 1
-        
+
         while not state.get_parent() is None:
             states.append(state.get_game_state())
             actions.append(action)
             solution_costs.append(cost)
-            
+
             action = state.get_action()
             state = state.get_parent()
             cost += 1
-            
+
         states.append(state.get_game_state())
         actions.append(action)
         solution_costs.append(cost)
-        
-        return Trajectory(states, actions, solution_costs, expanded)        
-     
+
+        return Trajectory(states, actions, solution_costs, expanded)
+
     def search(self, data):
         """
-        Performs PUCT search. 
-        
+        Performs PUCT search.
+
         Returns solution cost, number of nodes expanded, and generated
         """
-        state = data[0] 
+        state = data[0]
         puzzle_name = data[1]
         self._nn_model = data[2]
         budget = data[3]
         start_overall_time = data[4]
         time_limit = data[5]
         slack_time = data[6]
-        
+
         expanded = 0
-        
+
         start_time = time.time()
-        
+
         if self._use_learned_heuristic:
             _, action_probs, _ = self._nn_model.predict(np.array([state.get_image_representation()]))
         else:
             _, action_probs = self._nn_model.predict(np.array([state.get_image_representation()]))
-        
+
         root = PUCTTreeNode(None, state, -1, action_probs[0], 0, self._cpuct)
-        
+
         while True:
             nodes = []
             actions = []
-            
+
             while len(nodes) == 0:
                 distinct_nodes = set()
-                
+
                 for _ in range(self._k):
                     leaf_node, action = self._expand(root)
-                    
+
                     if action is None:
                         continue
-                    
+
                     if leaf_node.get_game_state() not in distinct_nodes:
                         distinct_nodes.add(leaf_node.get_game_state())
-                        
+
                         nodes.append(leaf_node)
                         actions.append(action)
-                        
+
                         expanded += 1
-                        
+
                         end_time = time.time()
                         if (budget > 0 and expanded > budget) or end_time - start_overall_time + slack_time > time_limit:
                                 return -1, expanded, 0, end_time - start_time, puzzle_name
-                    
+
             leaves, values = self._evaluate(nodes, actions)
-            
+
             for leaf_node in leaves:
                 if leaf_node.get_game_state().is_solution():
                     end_time = time.time()
                     return leaf_node.get_g(), expanded, 0, end_time - start_time, puzzle_name
-            
+
             self._backpropagate(leaves, values)
-            
-            


### PR DESCRIPTION
Emacs makes it impossible (visually) to keep trailing whitespaces. Do you think you can configure your editor to remove these automatically? If not I'll figure something out to avoid having large whitespace diffs each time I make a PR...